### PR TITLE
Fix broken README Supported Versions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ chmod +x uninstall-openmp.sh
 
 ## Supported Versions
 
+<!-- >>> BEGIN GENERATED README TABLE (managed by sync-openmp.sh; do not edit) >>> -->
 | Xcode Version | Apple Clang | OpenMP Version | Download |
 |---------------|-------------|----------------|----------|
-<!-- >>> BEGIN GENERATED README TABLE (managed by sync-openmp.sh; do not edit) >>> -->
 | 16.3-26.3 | 1700.x | 19.1.5 | [openmp-19.1.5-darwin20-Release.tar.gz](https://mac.r-project.org/openmp/openmp-19.1.5-darwin20-Release.tar.gz) |
 | 16.0-16.2 | 1600.x | 17.0.6 | [openmp-17.0.6-darwin20-Release.tar.gz](https://mac.r-project.org/openmp/openmp-17.0.6-darwin20-Release.tar.gz) |
 | 15.x | 1500.x | 16.0.4 | [openmp-16.0.4-darwin20-Release.tar.gz](https://mac.r-project.org/openmp/openmp-16.0.4-darwin20-Release.tar.gz) |

--- a/sync-openmp.sh
+++ b/sync-openmp.sh
@@ -63,6 +63,8 @@ render_help() {
 }
 
 render_readme() {
+  printf '| Xcode Version | Apple Clang | OpenMP Version | Download |\n'
+  printf '|---------------|-------------|----------------|----------|\n'
   while IFS=$'\t' read -r clang ver darwin sha xcode; do
     local short="${xcode#Xcode }"
     local file="openmp-${ver}-${darwin}-Release.tar.gz"

--- a/tests/test-render.sh
+++ b/tests/test-render.sh
@@ -14,6 +14,8 @@ help_out=$(printf '%s\n' "$rec" | render_help)
 assert_eq "$help_out" '    echo "    Xcode 16.3-26.3  → OpenMP 19.1.5"' "render_help single tier"
 
 readme_out=$(printf '%s\n' "$rec" | render_readme)
-want_readme='| 16.3-26.3 | 1700.x | 19.1.5 | [openmp-19.1.5-darwin20-Release.tar.gz](https://mac.r-project.org/openmp/openmp-19.1.5-darwin20-Release.tar.gz) |'
+want_readme='| Xcode Version | Apple Clang | OpenMP Version | Download |
+|---------------|-------------|----------------|----------|
+| 16.3-26.3 | 1700.x | 19.1.5 | [openmp-19.1.5-darwin20-Release.tar.gz](https://mac.r-project.org/openmp/openmp-19.1.5-darwin20-Release.tar.gz) |'
 assert_eq "$readme_out" "$want_readme" "render_readme single tier"
 echo "PASS: test-render"


### PR DESCRIPTION
The Supported Versions table rendered broken: the `<!-- BEGIN GENERATED README TABLE -->` comment sat between the table's separator row and the first data row, which terminates the Markdown table — leaving an empty header and rendering the data rows as literal pipe-delimited text.

## Fix

- `render_readme` (in `sync-openmp.sh`) now emits the header and delimiter rows, so the entire table lives inside the sync markers. The `BEGIN`/`END` comments now fall before the header and after the last row, where they don't interrupt rendering.
- `README.md` restructured accordingly (markers wrap the whole table).
- `tests/test-render.sh` updated to expect the header + delimiter in `render_readme`'s output.

`./sync-openmp.sh --check` reports **up to date** (the generator reproduces the new layout exactly), and the full test suite passes (6/6).